### PR TITLE
README file points to dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import Brightcove from 'component-brightcove';
 return <Brightcove/>;
 ```
 
-For more examples on usage, see [`src/example.es6`](./src/example.es6).
+For more examples on usage, see [`src/example.js`](./src/example.js).
 
 ## Install
 


### PR DESCRIPTION
it should be `examples.js` instead of `examples.es6`