### PR TITLE
WP-1490 prepare for react 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache:
   directories:
     - node_modules
 node_js:
-  - '4'
+  - '6'
   - stable
 after_success: >-
   travis-after-all && npm run semantic-release && npm run pages -- --repo

--- a/package.json
+++ b/package.json
@@ -107,7 +107,10 @@
   },
   "dependencies": {
     "lodash.uniqueid": "^4.0.0",
-    "react": "^0.14.8"
+    "prop-types": "^15.5.0"
+  },
+  "peerDependencies": {
+    "react": "^0.14.8||^15.0.0||^16.0.0"
   },
   "devDependencies": {
     "@economist/doc-pack": "^1.0.8",
@@ -123,10 +126,11 @@
     "browserify": "^13.0.0",
     "browserify-istanbul": "^2.0.0",
     "chai": "^3.5.0",
-    "chai-enzyme": "^0.4.2",
+    "chai-enzyme": "^1.0.0-beta.0",
     "chai-spies": "^0.7.1",
     "coveralls": "^2.11.9",
-    "enzyme": "^2.2.0",
+    "enzyme": "^3.0.0",
+    "enzyme-adapter-react-16": "^1.0.1",
     "eslint": "^2.8.0",
     "eslint-config-strict": "^8.5.1",
     "eslint-config-strict-react": "^8.0.1",
@@ -156,8 +160,8 @@
     "postcss-reporter": "^1.3.3",
     "postcss-url": "^5.1.1",
     "promisescript": "^1.1.0",
-    "react-addons-test-utils": "^0.14.8",
-    "react-dom": "^0.14.8",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "semantic-release": "^4.3.5",
     "stylelint": "^6.2.2",
     "stylelint-config-strict": "^5.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import lodashUniqid from 'lodash.uniqueid';
 
 const arbitraryDefaultWidth = 595;
@@ -80,16 +81,16 @@ export default class Brightcove extends React.Component {
 
 if (process.env.NODE_ENV !== 'production') {
   Brightcove.propTypes = {
-    experienceID: React.PropTypes.string,
-    videoID: React.PropTypes.string.isRequired,
-    playerID: React.PropTypes.string.isRequired,
-    playerKey: React.PropTypes.string.isRequired,
-    labels: React.PropTypes.string.isRequired,
-    width: React.PropTypes.number,
-    height: React.PropTypes.number,
-    secureConnections: React.PropTypes.bool,
-    getBrightcoveExperience: React.PropTypes.func,
-    onError: React.PropTypes.func,
-    autoStart: React.PropTypes.bool,
+    experienceID: PropTypes.string,
+    videoID: PropTypes.string.isRequired,
+    playerID: PropTypes.string.isRequired,
+    playerKey: PropTypes.string.isRequired,
+    labels: PropTypes.string.isRequired,
+    width: PropTypes.number,
+    height: PropTypes.number,
+    secureConnections: PropTypes.bool,
+    getBrightcoveExperience: PropTypes.func,
+    onError: PropTypes.func,
+    autoStart: PropTypes.bool,
   };
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,13 @@
 import 'babel-polyfill';
 import Brightcove from '../src';
 import React from 'react';
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 import chai from 'chai';
 import chaiSpies from 'chai-spies';
 import chaiEnzyme from 'chai-enzyme';
 import { mount } from 'enzyme';
+Enzyme.configure({ adapter: new Adapter() });
 chai.use(chaiEnzyme()).use(chaiSpies).should();
 
 describe('brightcove video', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,7 @@ import chaiEnzyme from 'chai-enzyme';
 import { mount } from 'enzyme';
 Enzyme.configure({ adapter: new Adapter() });
 chai.use(chaiEnzyme()).use(chaiSpies).should();
+mocha.setup({ globals: [ 'brightcove', 'brightcoveJS', 'checkLoad', 'experienceElement' ] });
 
 describe('brightcove video', () => {
   let getBrightcoveExperience = null;


### PR DESCRIPTION
A note from me:

- `enzyme` and `chai-enzyme` are used in tests, so have been upgraded
- Mocha detects so called "global leaks" and complains about global variables. This is good, however brightcove is leaking globals making mocha complain. I have suppressed the complains which we can do nothing about by adding offending globals to the whitelist. Adding it to the test is not particularly pretty, although my attempts to go through karma.conf and mocha.opts failed.